### PR TITLE
Add advanced stamp customization module features

### DIFF
--- a/modules/stampcustomizer/README.md
+++ b/modules/stampcustomizer/README.md
@@ -1,9 +1,9 @@
-# Stamp Customizer Module
+# Custom stamp MTB Module
 
-This PrestaShop module adds a stamp customization block to the home page. Customers can enter text and preview it as a stamp. Module settings allow you to define the stamp border, width, height, color and an optional bundle product ID in the back office.
+Custom stamp MTB is a PrestaShop module by Quentin Dsanti. It adds a stamp customization block to the home page where customers can enter text line by line and preview it as a stamp. Module settings allow you to define the stamp border, width, height, shape, price per line, number of lines, color and an optional bundle product ID in the back office.
 
 To install:
 1. Copy the `stampcustomizer` folder into your `modules` directory of PrestaShop.
 2. Install the module from the PrestaShop back office.
 
-After installation you can configure the module from the "Modules" section in the back office. Adjust the default border size, stamp dimensions, color or bundle product ID to fit your needs.
+After installation you can configure the module from the "Modules" section in the back office. Adjust the default border size, stamp dimensions, shape, price per line, maximum number of lines, color or bundle product ID to fit your needs.

--- a/modules/stampcustomizer/stampcustomizer.php
+++ b/modules/stampcustomizer/stampcustomizer.php
@@ -9,11 +9,11 @@ class StampCustomizer extends Module
     {
         $this->name = 'stampcustomizer';
         $this->tab = 'front_office_features';
-        $this->version = '1.1.0';
-        $this->author = 'Example';
+        $this->version = '1.2.1';
+        $this->author = 'Quentin Dsanti';
         $this->need_instance = 0;
         parent::__construct();
-        $this->displayName = $this->l('Stamp Customizer');
+        $this->displayName = $this->l('Custom stamp MTB');
         $this->description = $this->l('Allows customers to customize a stamp text.');
     }
 
@@ -25,6 +25,9 @@ class StampCustomizer extends Module
             && Configuration::updateValue('SC_HEIGHT', 80)
             && Configuration::updateValue('SC_COLOR', '#000000')
             && Configuration::updateValue('SC_BUNDLE_PRODUCT', 0)
+            && Configuration::updateValue('SC_SHAPE', 'rectangle')
+            && Configuration::updateValue('SC_PRICE_PER_LINE', 1)
+            && Configuration::updateValue('SC_LINES', 3)
             && $this->registerHook('displayHome');
     }
 
@@ -35,7 +38,10 @@ class StampCustomizer extends Module
             && Configuration::deleteByName('SC_WIDTH')
             && Configuration::deleteByName('SC_HEIGHT')
             && Configuration::deleteByName('SC_COLOR')
-            && Configuration::deleteByName('SC_BUNDLE_PRODUCT');
+            && Configuration::deleteByName('SC_BUNDLE_PRODUCT')
+            && Configuration::deleteByName('SC_SHAPE')
+            && Configuration::deleteByName('SC_PRICE_PER_LINE')
+            && Configuration::deleteByName('SC_LINES');
     }
 
     public function getContent()
@@ -46,6 +52,9 @@ class StampCustomizer extends Module
             Configuration::updateValue('SC_HEIGHT', (int)Tools::getValue('SC_HEIGHT'));
             Configuration::updateValue('SC_COLOR', Tools::getValue('SC_COLOR'));
             Configuration::updateValue('SC_BUNDLE_PRODUCT', (int)Tools::getValue('SC_BUNDLE_PRODUCT'));
+            Configuration::updateValue('SC_SHAPE', Tools::getValue('SC_SHAPE'));
+            Configuration::updateValue('SC_PRICE_PER_LINE', (float)Tools::getValue('SC_PRICE_PER_LINE'));
+            Configuration::updateValue('SC_LINES', (int)Tools::getValue('SC_LINES'));
             return $this->displayConfirmation($this->l('Settings updated')).$this->renderForm();
         }
 
@@ -81,6 +90,30 @@ class StampCustomizer extends Module
                         'name' => 'SC_COLOR',
                     ],
                     [
+                        'type' => 'select',
+                        'label' => $this->l('Shape'),
+                        'name' => 'SC_SHAPE',
+                        'options' => [
+                            'query' => [
+                                ['id' => 'rectangle', 'name' => $this->l('Rectangle')],
+                                ['id' => 'round', 'name' => $this->l('Round')],
+                                ['id' => 'oval', 'name' => $this->l('Oval')],
+                            ],
+                            'id' => 'id',
+                            'name' => 'name',
+                        ],
+                    ],
+                    [
+                        'type' => 'text',
+                        'label' => $this->l('Price per line'),
+                        'name' => 'SC_PRICE_PER_LINE',
+                    ],
+                    [
+                        'type' => 'text',
+                        'label' => $this->l('Maximum lines'),
+                        'name' => 'SC_LINES',
+                    ],
+                    [
                         'type' => 'text',
                         'label' => $this->l('Bundle product ID'),
                         'name' => 'SC_BUNDLE_PRODUCT',
@@ -106,6 +139,9 @@ class StampCustomizer extends Module
                 'SC_WIDTH' => Configuration::get('SC_WIDTH'),
                 'SC_HEIGHT' => Configuration::get('SC_HEIGHT'),
                 'SC_COLOR' => Configuration::get('SC_COLOR'),
+                'SC_SHAPE' => Configuration::get('SC_SHAPE'),
+                'SC_PRICE_PER_LINE' => Configuration::get('SC_PRICE_PER_LINE'),
+                'SC_LINES' => Configuration::get('SC_LINES'),
                 'SC_BUNDLE_PRODUCT' => Configuration::get('SC_BUNDLE_PRODUCT'),
             ],
         ];
@@ -117,11 +153,17 @@ class StampCustomizer extends Module
     {
         $this->context->controller->addCSS($this->_path.'views/css/stampcustomizer.css');
         $this->context->controller->addJS($this->_path.'views/js/stampcustomizer.js');
+        $shape = Configuration::get('SC_SHAPE');
+        $borderRadius = $shape === 'rectangle' ? '0' : '50%';
         $this->context->smarty->assign([
             'stamp_border' => Configuration::get('SC_BORDER'),
             'stamp_width' => Configuration::get('SC_WIDTH'),
             'stamp_height' => Configuration::get('SC_HEIGHT'),
             'stamp_color' => Configuration::get('SC_COLOR'),
+            'stamp_shape' => $shape,
+            'stamp_border_radius' => $borderRadius,
+            'stamp_price_per_line' => Configuration::get('SC_PRICE_PER_LINE'),
+            'stamp_lines' => (int)Configuration::get('SC_LINES'),
         ]);
         return $this->display(__FILE__, 'views/templates/hook/stampcustomizer.tpl');
     }

--- a/modules/stampcustomizer/views/css/stampcustomizer.css
+++ b/modules/stampcustomizer/views/css/stampcustomizer.css
@@ -8,4 +8,5 @@
   padding: 10px;
   border: 1px dashed #666;
   min-height: 50px;
+  box-sizing: border-box;
 }

--- a/modules/stampcustomizer/views/js/stampcustomizer.js
+++ b/modules/stampcustomizer/views/js/stampcustomizer.js
@@ -1,6 +1,17 @@
 $(document).ready(function() {
-  $('#stamp-submit').on('click', function() {
-    var text = $('#stamp-text').val();
-    $('#stamp-preview').text(text);
-  });
+  function updatePreview() {
+    var lines = [];
+    $('.stamp-line').each(function() {
+      var val = $(this).val();
+      if (val.trim() !== '') {
+        lines.push(val);
+      }
+    });
+    $('#stamp-preview').html(lines.join('<br/>'));
+    var price = lines.length * parseFloat(stamp_price_per_line);
+    $('#stamp-price').text(price.toFixed(2));
+  }
+
+  $('.stamp-line').on('input', updatePreview);
+  $('#stamp-submit').on('click', updatePreview);
 });

--- a/modules/stampcustomizer/views/templates/hook/stampcustomizer.tpl
+++ b/modules/stampcustomizer/views/templates/hook/stampcustomizer.tpl
@@ -1,6 +1,15 @@
 <div id="stamp-customizer">
-  <label for="stamp-text">{l s='Enter text for your stamp:'}</label>
-  <input type="text" id="stamp-text" class="form-control" />
+  {for $i=1 to $stamp_lines}
+    <div class="form-group">
+      <label for="stamp-line{$i}">{l s='Line'} {$i}</label>
+      <input type="text" id="stamp-line{$i}" class="form-control stamp-line" />
+    </div>
+  {/for}
+  <p><strong>{l s='Price:'} <span id="stamp-price">0</span></strong></p>
   <button type="button" id="stamp-submit" class="btn btn-primary" style="margin-top:10px;">{l s='Preview'}</button>
-  <div id="stamp-preview" style="border: {$stamp_border}px solid {$stamp_color}; width: {$stamp_width}px; height: {$stamp_height}px; color: {$stamp_color};"></div>
+  <div id="stamp-preview" style="border: {$stamp_border}px solid {$stamp_color}; width: {$stamp_width}px; height: {$stamp_height}px; color: {$stamp_color}; border-radius: {$stamp_border_radius};"></div>
 </div>
+<script>
+  var stamp_price_per_line = '{$stamp_price_per_line|escape:'javascript'}';
+  var stamp_max_lines = {$stamp_lines|intval};
+</script>


### PR DESCRIPTION
## Summary
- enhance stamp customizer module
- store shape, line count and price per line in module configuration
- generate line inputs and show price and preview dynamically
- add JS logic for multiple lines
- update README
- fix author name and module display title

## Testing
- `php -l modules/stampcustomizer/stampcustomizer.php`
- `node -c modules/stampcustomizer/views/js/stampcustomizer.js`


------
https://chatgpt.com/codex/tasks/task_e_6880defdf6a0832d9a843076782e2e73